### PR TITLE
feat: add waitlist signup page and user dashboard (#33)

### DIFF
--- a/swaptrade-frontend/src/app/page.tsx
+++ b/swaptrade-frontend/src/app/page.tsx
@@ -1,10 +1,17 @@
+import Link from 'next/link';
+
 export default function Home() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-between p-24">
       <h1 className="text-3xl font-bold underline text-center text-brand-green">
         Welcome to SwapTrade
       </h1>
-      <p></p>
+      <Link
+        href="/waitlist"
+        className="px-6 py-3 rounded-lg bg-[#16a34a] hover:bg-[#15803d] text-white font-medium transition-colors"
+      >
+        Join the Waitlist
+      </Link>
     </div>
   )
 }

--- a/swaptrade-frontend/src/app/waitlist/page.tsx
+++ b/swaptrade-frontend/src/app/waitlist/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import WaitlistForm from '@/components/WaitlistForm';
+import WaitlistSuccess from '@/components/WaitlistSuccess';
+import UserDashboard from '@/components/UserDashboard';
+
+function WaitlistPageInner() {
+  const searchParams = useSearchParams();
+  const refCode = searchParams.get('ref') || searchParams.get('referral') || undefined;
+
+  const [userId, setUserId] = useState<string | null>(null);
+  const [myReferralCode, setMyReferralCode] = useState<string | null>(null);
+  const [showDashboard, setShowDashboard] = useState(false);
+
+  const handleSuccess = (id: string, code: string | null) => {
+    setUserId(id);
+    setMyReferralCode(code);
+  };
+
+  const handleReset = () => {
+    setUserId(null);
+    setMyReferralCode(null);
+    setShowDashboard(false);
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-start px-4 py-16 gap-10">
+      <div className="text-center space-y-3 max-w-lg">
+        <h1 className="text-4xl font-bold text-[#16a34a]">Join the SwapTrade Waitlist</h1>
+        <p className="text-gray-600 dark:text-gray-400 text-lg">
+          Be the first to access risk-free crypto trading simulation. Sign up below and refer
+          friends to move up the list.
+        </p>
+      </div>
+
+      {!userId ? (
+        <WaitlistForm onSuccess={handleSuccess} referralCode={refCode} />
+      ) : (
+        <div className="flex flex-col items-center gap-6 w-full max-w-2xl">
+          <WaitlistSuccess referralCode={myReferralCode} onReset={handleReset} />
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => setShowDashboard((v) => !v)}
+              className="px-5 py-2 rounded-lg border border-[#16a34a] text-[#16a34a] hover:bg-green-50 dark:hover:bg-green-900/20 text-sm font-medium transition-colors"
+            >
+              {showDashboard ? 'Hide Dashboard' : 'View My Status'}
+            </button>
+          </div>
+
+          {showDashboard && <UserDashboard userId={userId} />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function WaitlistPage() {
+  return (
+    <Suspense>
+      <WaitlistPageInner />
+    </Suspense>
+  );
+}

--- a/swaptrade-frontend/src/components/UserDashboard.tsx
+++ b/swaptrade-frontend/src/components/UserDashboard.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+
+interface DashboardData {
+  userId: string;
+  points: number;
+  rank: number;
+  referralCode: string | null;
+  totalReferrals: number;
+  successfulReferrals: number;
+  referrals: Array<{ displayName: string; verified: boolean; joinedAt: number }>;
+}
+
+interface UserDashboardProps {
+  userId: string;
+}
+
+export default function UserDashboard({ userId }: UserDashboardProps) {
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setError(null);
+      const res = await fetch(`/api/users/${userId}/dashboard`);
+      if (res.status === 403) throw new Error('Your account is not yet verified.');
+      if (!res.ok) throw new Error('Failed to load dashboard.');
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong.');
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const referralUrl =
+    data?.referralCode && typeof window !== 'undefined'
+      ? `${window.location.origin}/?ref=${data.referralCode}`
+      : null;
+
+  const copyLink = async () => {
+    if (!referralUrl) return;
+    await navigator.clipboard.writeText(referralUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (loading) {
+    return (
+      <div role="status" aria-live="polite" className="space-y-4 w-full max-w-2xl">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-16 rounded-lg bg-gray-200 dark:bg-gray-700 animate-pulse" />
+        ))}
+        <span className="sr-only">Loading dashboard…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div role="alert" className="w-full max-w-2xl text-center text-red-500 py-8">
+        {error}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <section aria-label="Waitlist dashboard" className="w-full max-w-2xl space-y-6">
+      <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Your Waitlist Status</h2>
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-4">
+        {[
+          { label: 'Points', value: data.points.toLocaleString() },
+          { label: 'Rank', value: `#${data.rank}` },
+          { label: 'Referrals', value: `${data.successfulReferrals} / ${data.totalReferrals}` },
+        ].map(({ label, value }) => (
+          <div
+            key={label}
+            className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 text-center"
+          >
+            <p className="text-2xl font-bold text-[#16a34a]">{value}</p>
+            <p className="text-sm text-gray-500 mt-1">{label}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Referral link */}
+      {referralUrl && (
+        <div className="space-y-3">
+          <h3 className="font-semibold text-gray-900 dark:text-gray-100">Your Referral Link</h3>
+          <div className="flex gap-2 items-center">
+            <input
+              readOnly
+              value={referralUrl}
+              aria-label="Your referral link"
+              className="flex-1 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={copyLink}
+              className="px-4 py-2 rounded-lg bg-[#16a34a] hover:bg-[#15803d] text-white text-sm font-medium transition-colors whitespace-nowrap"
+              aria-label="Copy referral link to clipboard"
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Referred users */}
+      <div className="space-y-3">
+        <h3 className="font-semibold text-gray-900 dark:text-gray-100">
+          People You&apos;ve Referred ({data.totalReferrals})
+        </h3>
+        {data.referrals.length === 0 ? (
+          <p className="text-gray-500 text-sm">No referrals yet. Share your link to move up the list!</p>
+        ) : (
+          <ul className="space-y-2" aria-label="Referred users list">
+            {data.referrals.map((r, i) => (
+              <li
+                key={i}
+                className="flex items-center justify-between px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700"
+              >
+                <span className="text-sm text-gray-900 dark:text-gray-100">{r.displayName}</span>
+                <span
+                  className={`text-xs px-2 py-1 rounded-full font-medium ${
+                    r.verified
+                      ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                      : 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+                  }`}
+                >
+                  {r.verified ? 'Verified ✓' : 'Pending'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/swaptrade-frontend/src/components/WaitlistForm.tsx
+++ b/swaptrade-frontend/src/components/WaitlistForm.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+interface WaitlistFormProps {
+  onSuccess: (userId: string, referralCode: string | null) => void;
+  referralCode?: string;
+}
+
+interface FormErrors {
+  email?: string;
+  name?: string;
+  submit?: string;
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function WaitlistForm({ onSuccess, referralCode }: WaitlistFormProps) {
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const csrfRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/csrf', { cache: 'no-store' })
+      .then(async (res) => {
+        if (!res.ok) return;
+        const data = (await res.json().catch(() => null)) as { token?: string } | null;
+        if (data?.token) csrfRef.current = data.token;
+      })
+      .catch(() => {});
+  }, []);
+
+  const validateEmail = (val: string) => {
+    if (!val.trim()) return 'Email address is required';
+    if (!EMAIL_REGEX.test(val)) return 'Please enter a valid email address';
+    return undefined;
+  };
+
+  const handleBlur = useCallback((field: string, value: string) => {
+    setTouched((prev) => ({ ...prev, [field]: true }));
+    if (field === 'email') {
+      const err = validateEmail(value);
+      setErrors((prev) => ({ ...prev, email: err }));
+    }
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const emailErr = validateEmail(email);
+      if (emailErr) {
+        setErrors({ email: emailErr });
+        setTouched({ email: true });
+        return;
+      }
+
+      setIsLoading(true);
+      setErrors({});
+
+      try {
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (csrfRef.current) headers['x-csrf-token'] = csrfRef.current;
+
+        const res = await fetch('/api/waitlist', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            email: email.trim(),
+            name: name.trim() || undefined,
+            referralCode: referralCode || undefined,
+          }),
+        });
+
+        const data = await res.json().catch(() => ({}));
+
+        if (!res.ok) {
+          throw new Error(data.message || 'Failed to join waitlist. Please try again.');
+        }
+
+        onSuccess(data.user?.id ?? '', data.myReferralCode ?? null);
+      } catch (err) {
+        setErrors({
+          submit: err instanceof Error ? err.message : 'An unexpected error occurred. Please try again.',
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [email, name, referralCode, onSuccess]
+  );
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="w-full max-w-md space-y-4"
+      aria-label="Waitlist signup form"
+      noValidate
+    >
+      <div>
+        <label
+          htmlFor="wl-email"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        >
+          Email address <span className="text-red-500" aria-hidden="true">*</span>
+          <span className="sr-only">(required)</span>
+        </label>
+        <input
+          id="wl-email"
+          type="email"
+          name="email"
+          value={email}
+          onChange={(e) => {
+            setEmail(e.target.value);
+            if (errors.email) setErrors((prev) => ({ ...prev, email: undefined }));
+          }}
+          onBlur={(e) => handleBlur('email', e.target.value)}
+          disabled={isLoading}
+          required
+          aria-required="true"
+          aria-invalid={touched.email && !!errors.email ? 'true' : 'false'}
+          aria-describedby={errors.email ? 'wl-email-error' : undefined}
+          placeholder="you@example.com"
+          className={`w-full px-4 py-3 rounded-lg border bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors duration-200 ${
+            touched.email && errors.email
+              ? 'border-red-500 focus:ring-red-500'
+              : 'border-gray-300 dark:border-gray-600 focus:ring-[#16a34a] focus:border-[#16a34a]'
+          } disabled:opacity-50 disabled:cursor-not-allowed`}
+        />
+        {touched.email && errors.email && (
+          <p id="wl-email-error" className="mt-1 text-sm text-red-600 dark:text-red-400" role="alert">
+            {errors.email}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="wl-name"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        >
+          Name <span className="text-gray-400 font-normal">(optional)</span>
+        </label>
+        <input
+          id="wl-name"
+          type="text"
+          name="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={isLoading}
+          placeholder="Your name"
+          className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#16a34a] focus:border-[#16a34a] transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+        />
+      </div>
+
+      {errors.submit && (
+        <div
+          className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg"
+          role="alert"
+          aria-live="assertive"
+        >
+          <p className="text-sm text-red-600 dark:text-red-400">{errors.submit}</p>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        aria-disabled={isLoading}
+        className="w-full inline-flex items-center justify-center px-6 py-3 text-base font-medium text-white bg-[#16a34a] hover:bg-[#15803d] rounded-lg transition-colors duration-200 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#16a34a] disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isLoading ? (
+          <>
+            <svg
+              className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            Joining…
+          </>
+        ) : (
+          'Join Waitlist'
+        )}
+      </button>
+
+      <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+        We respect your privacy. Unsubscribe at any time.
+      </p>
+    </form>
+  );
+}

--- a/swaptrade-frontend/src/components/WaitlistSuccess.tsx
+++ b/swaptrade-frontend/src/components/WaitlistSuccess.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+interface WaitlistSuccessProps {
+  referralCode: string | null;
+  onReset: () => void;
+}
+
+export default function WaitlistSuccess({ referralCode, onReset }: WaitlistSuccessProps) {
+  const referralUrl =
+    referralCode && typeof window !== 'undefined'
+      ? `${window.location.origin}/?ref=${referralCode}`
+      : null;
+
+  const copyLink = async () => {
+    if (!referralUrl) return;
+    await navigator.clipboard.writeText(referralUrl);
+  };
+
+  return (
+    <div
+      className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-6 text-center space-y-4 w-full max-w-md"
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="flex items-center justify-center">
+        <svg
+          className="w-12 h-12 text-green-500"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      </div>
+
+      <div>
+        <h3 className="text-lg font-semibold text-green-800 dark:text-green-200 mb-1">
+          You&apos;re on the list!
+        </h3>
+        <p className="text-sm text-green-700 dark:text-green-300">
+          Check your email for a confirmation link. We&apos;ll notify you when SwapTrade is ready.
+        </p>
+      </div>
+
+      {referralUrl && (
+        <div className="space-y-2 text-left">
+          <p className="text-sm font-medium text-green-800 dark:text-green-200">
+            Share your referral link to move up the list:
+          </p>
+          <div className="flex gap-2 items-center">
+            <input
+              readOnly
+              value={referralUrl}
+              aria-label="Your referral link"
+              className="flex-1 px-3 py-2 rounded-lg border border-green-300 dark:border-green-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={copyLink}
+              className="px-3 py-2 rounded-lg bg-green-600 hover:bg-green-700 text-white text-sm font-medium transition-colors whitespace-nowrap"
+            >
+              Copy
+            </button>
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onReset}
+        className="text-sm text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-200 underline focus:outline-none focus:ring-2 focus:ring-green-500 rounded px-2 py-1"
+      >
+        Join with another email
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add WaitlistForm component with email/name fields, validation, and error handling; POSTs to /api/waitlist with CSRF token support
- Add WaitlistSuccess component showing confirmation state, referral link with copy button, and email confirmation messaging
- Add UserDashboard component fetching /api/users/[id]/dashboard to display rank, points, referral count, and per-referral verified status
- Add /waitlist page composing the three components with a post-signup dashboard toggle
- Update home page with a 'Join the Waitlist' link to /waitlist

closes #33