### PR TITLE
Feat/waitdiscord

### DIFF
--- a/src/app/(landing)/waitlist/components/DiscordCommunityCTA.tsx
+++ b/src/app/(landing)/waitlist/components/DiscordCommunityCTA.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+export default function DiscordCommunityCTA({ userId, isPremium }: { userId?: string; isPremium?: boolean }) {
+  const [memberCount, setMemberCount] = useState<number | null>(null);
+  const [events, setEvents] = useState<Array<{ id: string; title: string; time: string }>>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    Promise.all([
+      fetch('/api/discord/stats').then((r) => r.ok ? r.json() : Promise.reject()).catch(() => null),
+      fetch('/api/discord/events').then((r) => r.ok ? r.json() : Promise.reject()).catch(() => ({ events: [] })),
+    ]).then(([stats, ev]) => {
+      if (!mounted) return;
+      setMemberCount(stats?.memberCount ?? null);
+      setEvents(ev?.events ?? []);
+      setLoading(false);
+    });
+
+    return () => { mounted = false; };
+  }, []);
+
+  const connectDiscord = () => {
+    // redirect to server OAuth start
+    window.location.href = '/api/discord/auth';
+  };
+
+  return (
+    <section className="p-4 rounded-lg border border-gray-200 bg-white max-w-3xl mx-auto">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">Join our Discord community</h3>
+          <p className="text-sm text-gray-600">Connect with fellow waitlist members, get updates, and join AMAs.</p>
+        </div>
+        <div>
+          <button
+            onClick={connectDiscord}
+            className="px-4 py-2 rounded bg-indigo-600 text-white"
+          >Connect Discord</button>
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="p-3 rounded border border-gray-100">
+          <p className="text-xs text-gray-500">Members</p>
+          <p className="text-xl font-bold">{loading ? '…' : (memberCount ?? 'Unknown')}</p>
+        </div>
+
+        <div className="p-3 rounded border border-gray-100 col-span-2">
+          <p className="text-xs text-gray-500">Upcoming events</p>
+          {events.length === 0 ? (
+            <p className="text-sm text-gray-600">No upcoming events. Check back later.</p>
+          ) : (
+            <ul className="mt-2 text-sm space-y-1">
+              {events.map((e) => (
+                <li key={e.id} className="flex justify-between">
+                  <span>{e.title}</span>
+                  <span className="text-gray-500">{new Date(e.time).toLocaleString()}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {isPremium && (
+        <div className="mt-4 p-3 rounded border border-yellow-100 bg-yellow-50">
+          <p className="text-sm">As a Premium member you'll receive the <strong>Premium Waitlist</strong> Discord role automatically when you connect.</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/(landing)/waitlist/components/ReferralProgram.tsx
+++ b/src/app/(landing)/waitlist/components/ReferralProgram.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import ReferralLink from '@/components/referral/ReferralLink';
+import QRCodeDisplay from '@/components/QRCodeDisplay';
+import { fetchDashboard, trackShare } from '@/store/referralSlice';
+
+type LeaderboardItem = {
+  displayName: string;
+  referrals: number;
+  rank: number;
+};
+
+function maskName(name: string) {
+  if (!name) return 'Anonymous';
+  // show first char and a short suffix, keep anonymous feel
+  return `${name.charAt(0)}***#${(Math.abs(hashCode(name)) % 9000) + 1000}`;
+}
+
+function hashCode(str: string) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) h = (h << 5) - h + str.charCodeAt(i);
+  return h | 0;
+}
+
+export default function ReferralProgram({ userId, isPremium }: { userId: string; isPremium?: boolean }) {
+  const dispatch = useAppDispatch();
+  const { data } = useAppSelector((s) => s.referral);
+  const [leaderboard, setLeaderboard] = useState<LeaderboardItem[]>([]);
+  const [streamError, setStreamError] = useState<string | null>(null);
+  const [notifiedMilestones, setNotifiedMilestones] = useState<Record<number, boolean>>({});
+
+  useEffect(() => {
+    if (!userId) return;
+    dispatch(fetchDashboard(userId));
+
+    let mounted = true;
+
+    // fetch leaderboard snapshot
+    fetch('/api/referrals/leaderboard')
+      .then((r) => r.ok ? r.json() : Promise.reject('Failed'))
+      .then((json) => {
+        if (!mounted) return;
+        setLeaderboard(json.leaderboard || []);
+      })
+      .catch(() => {
+        // ignore — leaderboard optional
+      });
+
+    // try real-time updates via EventSource
+    let es: EventSource | null = null;
+    try {
+      es = new EventSource('/api/referrals/leaderboard/stream');
+      es.onmessage = (ev) => {
+        try {
+          const parsed = JSON.parse(ev.data);
+          if (Array.isArray(parsed)) setLeaderboard(parsed as LeaderboardItem[]);
+        } catch (err) {
+          // ignore
+        }
+      };
+      es.onerror = () => setStreamError('Leaderboard realtime connection failed');
+    } catch (err) {
+      // EventSource not available or not supported
+    }
+
+    return () => {
+      mounted = false;
+      if (es) es.close();
+    };
+  }, [dispatch, userId]);
+
+  // computed values
+  const referralUrl = useMemo(() => {
+    if (!data?.referralCode) return null;
+    if (typeof window === 'undefined') return `/?ref=${data.referralCode}`;
+    return `${window.location.origin}/?ref=${data.referralCode}`;
+  }, [data?.referralCode]);
+
+  const advancementPerReferral = isPremium ? 2 : 1;
+  const totalAdvancement = (data?.successfulReferrals || 0) * advancementPerReferral;
+
+  // send milestone notification request when hit 5 referrals (free premium month)
+  useEffect(() => {
+    if (!userId || !data) return;
+    const count = data.successfulReferrals || 0;
+    const milestones = [5];
+    milestones.forEach((m) => {
+      if (count >= m && !notifiedMilestones[m]) {
+        // request backend to send email/notification for milestone
+        fetch(`/api/users/${userId}/notify-milestone`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ milestone: m, referrals: count }),
+        }).catch(() => {});
+        setNotifiedMilestones((p) => ({ ...p, [m]: true }));
+      }
+    });
+  }, [data, userId, notifiedMilestones]);
+
+  const handleShare = async (channel: string) => {
+    if (!data?.referralCode) return;
+    dispatch(trackShare({ userId, referralCode: data.referralCode, shareChannel: channel as any } as any));
+  };
+
+  if (!data) return null;
+
+  return (
+    <section aria-label="Referral program" className="space-y-6 max-w-3xl mx-auto p-4">
+      <h2 className="text-2xl font-semibold">Invite friends — move up the waitlist</h2>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          {data.referralCode && <ReferralLink referralCode={data.referralCode} />}
+
+          <div className="mt-4 space-y-2 p-4 rounded-lg border border-gray-200 bg-gray-50">
+            <p className="text-sm">Referrals: <strong>{data.successfulReferrals}</strong></p>
+            <p className="text-sm">Waitlist advancement: <strong>{totalAdvancement} positions</strong></p>
+            <p className="text-sm">Per-referral credit: <strong>{advancementPerReferral}</strong></p>
+            <p className="text-sm">Free premium month at <strong>5</strong> referrals.</p>
+          </div>
+
+          {/* sharing buttons */}
+          <div className="mt-4 space-y-2">
+            <p className="text-sm font-medium">Share</p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => { handleShare('twitter'); window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent('Join me on SwapTrade — a crypto trading simulator!')}&url=${encodeURIComponent(referralUrl || '')}`,'_blank'); }}
+                className="px-3 py-2 rounded bg-sky-500 text-white text-sm"
+              >Twitter / X</button>
+
+              <button
+                onClick={() => { handleShare('telegram'); window.open(`https://t.me/share/url?url=${encodeURIComponent(referralUrl || '')}&text=${encodeURIComponent('Join SwapTrade — risk-free crypto trading simulator!')}`,'_blank'); }}
+                className="px-3 py-2 rounded bg-blue-400 text-white text-sm"
+              >Telegram</button>
+
+              <button
+                onClick={() => { handleShare('discord'); window.open('https://discord.com/channels/@me','_blank'); }}
+                className="px-3 py-2 rounded bg-violet-600 text-white text-sm"
+              >Discord</button>
+
+              <button
+                onClick={() => { handleShare('email'); window.location.href = `mailto:?subject=${encodeURIComponent('Join SwapTrade')}&body=${encodeURIComponent(`Join SwapTrade — sign up with my referral link: ${referralUrl}`)}`; }}
+                className="px-3 py-2 rounded bg-gray-700 text-white text-sm"
+              >Email</button>
+
+              <button
+                onClick={() => { handleShare('copy'); navigator.clipboard.writeText(referralUrl || ''); }}
+                className="px-3 py-2 rounded bg-gray-300 text-black text-sm"
+              >Copy Link</button>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="p-4 rounded-lg border border-gray-200 bg-white space-y-3">
+            <h3 className="text-lg font-medium">Leaderboard</h3>
+            {streamError && <p className="text-xs text-red-500">{streamError}</p>}
+            <ol className="space-y-2">
+              {leaderboard.slice(0, 10).map((it) => (
+                <li key={it.rank} className="flex items-center justify-between">
+                  <div>
+                    <span className="font-medium">#{it.rank}</span>
+                    <span className="ml-2 text-sm text-gray-600">{maskName(it.displayName)}</span>
+                  </div>
+                  <div className="text-sm font-semibold">{it.referrals}</div>
+                </li>
+              ))}
+            </ol>
+
+            <div className="mt-3 text-xs text-gray-500">
+              Top referrers receive exclusive rewards. Your progress updates in near real-time.
+            </div>
+          </div>
+
+          <div className="mt-4 p-4 rounded-lg border border-gray-200 bg-gray-50">
+            <p className="text-sm">Exclusive milestones</p>
+            <ul className="text-sm list-disc ml-5 mt-2 space-y-1">
+              <li>Move up <strong>1</strong> position per referral (<strong>2</strong> if Premium).</li>
+              <li>Free Premium month at <strong>5</strong> successful referrals.</li>
+              <li>Top referrers get early access and exclusive badges.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {/* QR preview */}
+      {referralUrl && (
+        <div className="flex items-center gap-4">
+          <QRCodeDisplay url={referralUrl} referralCode={data.referralCode || ''} size={120} onDownload={() => handleShare('qr')} />
+          <div className="text-sm text-gray-600">Scan to join using your referral link.</div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/api/discord/auth/route.ts
+++ b/src/app/api/discord/auth/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+
+const DISCORD_OAUTH_URL = 'https://discord.com/api/oauth2/authorize';
+
+export function GET() {
+  const clientId = process.env.DISCORD_CLIENT_ID;
+  const redirect = process.env.NEXT_PUBLIC_BASE_URL ? `${process.env.NEXT_PUBLIC_BASE_URL}/api/discord/callback` : '/api/discord/callback';
+  if (!clientId) return NextResponse.json({ message: 'Discord not configured' }, { status: 500 });
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirect,
+    response_type: 'code',
+    scope: 'identify guilds.join email',
+    prompt: 'consent',
+  });
+
+  return NextResponse.redirect(`${DISCORD_OAUTH_URL}?${params.toString()}`);
+}

--- a/src/app/api/discord/callback/route.ts
+++ b/src/app/api/discord/callback/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+
+const DISCORD_TOKEN_URL = 'https://discord.com/api/oauth2/token';
+const DISCORD_API = 'https://discord.com/api/v10';
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const code = url.searchParams.get('code');
+  if (!code) return NextResponse.json({ message: 'Missing code' }, { status: 400 });
+
+  const clientId = process.env.DISCORD_CLIENT_ID;
+  const clientSecret = process.env.DISCORD_CLIENT_SECRET;
+  const redirect = process.env.NEXT_PUBLIC_BASE_URL ? `${process.env.NEXT_PUBLIC_BASE_URL}/api/discord/callback` : `${url.origin}/api/discord/callback`;
+  if (!clientId || !clientSecret) return NextResponse.json({ message: 'Discord not configured' }, { status: 500 });
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirect,
+  });
+
+  try {
+    const tokenRes = await fetch(DISCORD_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+    if (!tokenRes.ok) return NextResponse.json({ message: 'Token exchange failed' }, { status: 502 });
+    const tokenJson = await tokenRes.json();
+
+    // Get user's Discord identity
+    const meRes = await fetch(`${DISCORD_API}/users/@me`, { headers: { Authorization: `Bearer ${tokenJson.access_token}` } });
+    if (!meRes.ok) return NextResponse.json({ message: 'Failed to fetch Discord user' }, { status: 502 });
+    const me = await meRes.json();
+
+    // At this point, the server should associate discord id with our user and assign roles via bot token
+    // For now redirect back to /confirm with success
+    const redirectUrl = `${url.origin}/?discordConnected=1`;
+    return NextResponse.redirect(redirectUrl);
+  } catch (err) {
+    return NextResponse.json({ message: 'Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/discord/events/route.ts
+++ b/src/app/api/discord/events/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+// Minimal events endpoint: in production this would read from a CMS or DB
+export async function GET() {
+  const now = Date.now();
+  const events = [
+    { id: 'ama-1', title: 'AMA with founders', time: new Date(now + 1000 * 60 * 60 * 24).toISOString() },
+    { id: 'event-2', title: 'Community trading challenge', time: new Date(now + 1000 * 60 * 60 * 24 * 3).toISOString() },
+  ];
+  return NextResponse.json({ events });
+}

--- a/src/app/api/discord/stats/route.ts
+++ b/src/app/api/discord/stats/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+const DISCORD_API = 'https://discord.com/api/v10';
+
+export async function GET() {
+  const guildId = process.env.DISCORD_GUILD_ID;
+  const botToken = process.env.DISCORD_BOT_TOKEN;
+  if (!guildId || !botToken) {
+    return NextResponse.json({ message: 'Discord not configured' }, { status: 500 });
+  }
+
+  try {
+    const res = await fetch(`${DISCORD_API}/guilds/${guildId}?with_counts=true`, {
+      headers: { Authorization: `Bot ${botToken}` },
+    });
+    if (!res.ok) return NextResponse.json({ message: 'Failed' }, { status: 502 });
+    const data = await res.json();
+    return NextResponse.json({ memberCount: data.approximate_member_count ?? data.approximate_presence_count ?? null });
+  } catch (err) {
+    return NextResponse.json({ message: 'Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/discord/sync/route.ts
+++ b/src/app/api/discord/sync/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+const DISCORD_API = 'https://discord.com/api/v10';
+
+export async function POST(req: Request) {
+  const botToken = process.env.DISCORD_BOT_TOKEN;
+  const guildId = process.env.DISCORD_GUILD_ID;
+  if (!botToken || !guildId) return NextResponse.json({ message: 'Discord not configured' }, { status: 500 });
+
+  try {
+    const { discordId, addPremium } = await req.json();
+    if (!discordId) return NextResponse.json({ message: 'Missing discordId' }, { status: 400 });
+
+    // role ids should be configured via env
+    const premiumRole = process.env.DISCORD_PREMIUM_ROLE_ID;
+    if (!premiumRole) return NextResponse.json({ message: 'Premium role not configured' }, { status: 500 });
+
+    // Add or remove role
+    const method = addPremium ? 'PUT' : 'DELETE';
+    const url = `${DISCORD_API}/guilds/${guildId}/members/${discordId}/roles/${premiumRole}`;
+    const res = await fetch(url, { method, headers: { Authorization: `Bot ${botToken}` } });
+    if (!res.ok) return NextResponse.json({ message: 'Failed to update role' }, { status: 502 });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return NextResponse.json({ message: 'Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/discord/welcome/route.ts
+++ b/src/app/api/discord/welcome/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+const DISCORD_API = 'https://discord.com/api/v10';
+
+export async function POST(req: Request) {
+  const webhook = process.env.DISCORD_WELCOME_WEBHOOK_URL;
+  if (!webhook) return NextResponse.json({ message: 'No webhook configured' }, { status: 500 });
+
+  try {
+    const body = await req.json();
+    const { discordId, displayName } = body;
+    const content = `Welcome <@${discordId}>! 🎉\nThanks for joining the SwapTrade community, ${displayName || 'friend'}.`;
+    await fetch(webhook, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content }) });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return NextResponse.json({ message: 'Error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
**What I added**
- - **Component:** DiscordCommunityCTA.tsx — CTA to connect Discord, shows member count and upcoming events. See src/app/(landing)/waitlist/components/DiscordCommunityCTA.tsx/waitlist/components/DiscordCommunityCTA.tsx).
- - **APIs:** lightweight server routes to support Discord features:
  - route.ts — starts OAuth redirect.
  - route.ts — exchanges code, fetches Discord user (placeholder for role assignment).
  - route.ts — returns guild member counts.
  - route.ts — sample upcoming events feed.
  - route.ts — posts welcome messages to a configured webhook.
  - route.ts — adds/removes premium role for a guild member.
- - **Referral integration:** ReferralProgram.tsx already added earlier to present referrals, leaderboard, QR, sharing, and milestone notify calls.

**Environment variables required**
- - **Discord OAuth / bot:** `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`
- - **Roles / webhook:** `DISCORD_PREMIUM_ROLE_ID`, `DISCORD_WELCOME_WEBHOOK_URL`
- - Optionally: `NEXT_PUBLIC_BASE_URL` for OAuth redirect URL.

**How to try locally**
- 1) Set env vars (example):
   - `export DISCORD_CLIENT_ID=...`
   - `export DISCORD_CLIENT_SECRET=...`
   - `export DISCORD_BOT_TOKEN=...`
   - `export DISCORD_GUILD_ID=...`
   - `export DISCORD_PREMIUM_ROLE_ID=...`
   - `export DISCORD_WELCOME_WEBHOOK_URL=...`
- 2) Run dev server:
```bash
npm install
npm run dev
```
- 3) Open the waitlist page and click "Connect Discord" to test the OAuth redirect (you'll need real Discord credentials).

**Notes / limitations**
- The OAuth callback currently exchanges the code and fetches the Discord user, but does not yet perform automatic guild role assignment — that requires a server-side bot action (use `DISCORD_BOT_TOKEN`) and linkage between your app user and the Discord ID. I added `/api/discord/sync` to perform role add/remove; you can call it once you persist discordId → user mapping.
- The welcome message endpoint posts to a configured webhook; you should secure it (verify origin or require auth) before production.
- Leaderboard real-time and referral attribution require server-side logic (DB changes) and tests if you want full end-to-end coverage. I left API placeholders and basic flows wired so the frontend can call them.

**Next steps I can implement for you**
- Wire automatic role assignment in `/api/discord/callback` (use bot token to add member or role).
- Secure the webhook and add server-side triggers so new waitlist members get invited/assigned roles and welcome messages.
- Add server-side tests and a sample integration flow to sync roles when a user upgrades to Premium.
Tell me which of these you'd like next and I’ll proceed (I’ve updated the project TODOs accordingly).

Made changes.


Closes #67 