### PR TITLE
feat: premium countdown timer with real-time spot tracking

### DIFF
--- a/src/app/(landing)/waitlist/components/PremiumCountdown.tsx
+++ b/src/app/(landing)/waitlist/components/PremiumCountdown.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const TOTAL_SPOTS = 500;
+const LOW_SPOT_THRESHOLD = 0.1; // 10% = 50 spots
+const POLL_INTERVAL_MS = 2000;
+const SOCIAL_PROOF_REFRESH_MS = 15 * 60 * 1000;
+
+type SpotStats = {
+  spotsAvailable: number;
+  spotsTotal: number;
+  priceIncreasesAt: number;
+  serverTime: number;
+  recentSignups: number;
+};
+
+function pad(n: number) {
+  return String(n).padStart(2, '0');
+}
+
+function useAnimatedNumber(value: number) {
+  const [display, setDisplay] = useState(value);
+  const [flash, setFlash] = useState(false);
+  const prev = useRef(value);
+
+  useEffect(() => {
+    if (value === prev.current) return;
+    prev.current = value;
+    setFlash(true);
+    setDisplay(value);
+    const t = setTimeout(() => setFlash(false), 600);
+    return () => clearTimeout(t);
+  }, [value]);
+
+  return { display, flash };
+}
+
+function Countdown({ endsAt, serverTime }: { endsAt: number; serverTime: number }) {
+  // Offset between server clock and local clock so the countdown is tamper-resistant
+  const clockOffset = useRef(serverTime - Date.now());
+  const [remaining, setRemaining] = useState(() =>
+    Math.max(0, endsAt - (Date.now() + clockOffset.current))
+  );
+
+  useEffect(() => {
+    const tick = () =>
+      setRemaining(Math.max(0, endsAt - (Date.now() + clockOffset.current)));
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [endsAt]);
+
+  const days = Math.floor(remaining / 86_400_000);
+  const hours = Math.floor((remaining % 86_400_000) / 3_600_000);
+  const mins = Math.floor((remaining % 3_600_000) / 60_000);
+  const secs = Math.floor((remaining % 60_000) / 1_000);
+
+  const parts = days > 0
+    ? [{ label: 'days', value: days }, { label: 'hrs', value: hours }, { label: 'min', value: mins }, { label: 'sec', value: secs }]
+    : [{ label: 'hrs', value: hours }, { label: 'min', value: mins }, { label: 'sec', value: secs }];
+
+  return (
+    <div className="flex items-center gap-2 justify-center flex-wrap">
+      {parts.map(({ label, value }, i) => (
+        <span key={label} className="flex items-center gap-1">
+          {i > 0 && <span className="text-orange-400 font-bold">:</span>}
+          <span className="inline-flex flex-col items-center">
+            <span className="font-mono text-2xl font-black text-white tabular-nums w-10 text-center">
+              {pad(value)}
+            </span>
+            <span className="text-[10px] text-slate-400 uppercase tracking-widest">{label}</span>
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function PremiumCountdown() {
+  const [stats, setStats] = useState<SpotStats | null>(null);
+  const [error, setError] = useState(false);
+
+  const fetchStats = async () => {
+    try {
+      const res = await fetch('/api/waitlist/spots', { cache: 'no-store' });
+      if (!res.ok) throw new Error('fetch');
+      const data = (await res.json()) as SpotStats;
+      setStats(data);
+      setError(false);
+    } catch {
+      setError(true);
+    }
+  };
+
+  // Initial fetch + polling for spot count (every 2 s)
+  useEffect(() => {
+    fetchStats();
+    const poll = setInterval(fetchStats, POLL_INTERVAL_MS);
+    return () => clearInterval(poll);
+  }, []);
+
+  // Social proof refreshes every 15 min — we just re-use the main poll, 
+  // but the server only counts signups in the last hour so this is naturally fresh.
+  useEffect(() => {
+    const id = setInterval(fetchStats, SOCIAL_PROOF_REFRESH_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  const spotsAvailable = stats?.spotsAvailable ?? TOTAL_SPOTS;
+  const isLow = spotsAvailable / (stats?.spotsTotal ?? TOTAL_SPOTS) < LOW_SPOT_THRESHOLD;
+  const isSoldOut = spotsAvailable === 0;
+
+  const { display: displayedSpots, flash } = useAnimatedNumber(spotsAvailable);
+
+  const urgencyColor = isSoldOut
+    ? 'text-red-400'
+    : isLow
+    ? 'text-orange-400'
+    : 'text-amber-300';
+
+  const urgencyBorder = isSoldOut
+    ? 'border-red-500/50'
+    : isLow
+    ? 'border-orange-500/50'
+    : 'border-amber-500/30';
+
+  const urgencyBg = isSoldOut
+    ? 'from-red-900/30 to-red-800/20'
+    : isLow
+    ? 'from-orange-900/30 to-orange-800/20'
+    : 'from-amber-900/20 to-slate-800/20';
+
+  if (error && !stats) return null;
+
+  return (
+    <div
+      className={`rounded-2xl border ${urgencyBorder} bg-gradient-to-br ${urgencyBg} p-6 space-y-5 w-full max-w-sm mx-auto`}
+      role="region"
+      aria-label="Premium spot availability"
+    >
+      {/* Spots remaining */}
+      <div className="text-center space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+          Founding spots remaining
+        </p>
+        <div className="flex items-baseline justify-center gap-2">
+          <span
+            className={`font-black text-5xl tabular-nums transition-all duration-300 ${urgencyColor} ${
+              flash ? 'scale-110' : 'scale-100'
+            }`}
+          >
+            {isSoldOut ? '0' : displayedSpots.toLocaleString()}
+          </span>
+          <span className="text-slate-400 text-sm">/ {(stats?.spotsTotal ?? TOTAL_SPOTS).toLocaleString()}</span>
+        </div>
+
+        {isSoldOut ? (
+          <p className="text-red-400 text-sm font-semibold animate-pulse">
+            🔴 All spots taken
+          </p>
+        ) : isLow ? (
+          <p className="text-orange-400 text-sm font-semibold animate-pulse">
+            ⚠️ Almost gone — act now
+          </p>
+        ) : null}
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-2 rounded-full bg-slate-700 overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-700 ${
+            isSoldOut
+              ? 'bg-red-500'
+              : isLow
+              ? 'bg-gradient-to-r from-orange-500 to-red-500'
+              : 'bg-gradient-to-r from-amber-400 to-orange-500'
+          }`}
+          style={{
+            width: `${Math.min(
+              100,
+              (((stats?.spotsTotal ?? TOTAL_SPOTS) - spotsAvailable) /
+                (stats?.spotsTotal ?? TOTAL_SPOTS)) *
+                100
+            )}%`,
+          }}
+        />
+      </div>
+
+      {/* Countdown */}
+      {stats && !isSoldOut && (
+        <div className="text-center space-y-1 border-t border-slate-700/60 pt-4">
+          <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">
+            Launch price increases in
+          </p>
+          <Countdown endsAt={stats.priceIncreasesAt} serverTime={stats.serverTime} />
+        </div>
+      )}
+
+      {/* Social proof */}
+      {stats && stats.recentSignups > 0 && !isSoldOut && (
+        <p className="text-center text-xs text-slate-400">
+          🔥{' '}
+          <span className="text-amber-300 font-semibold">
+            {stats.recentSignups}
+          </span>{' '}
+          {stats.recentSignups === 1 ? 'spot' : 'spots'} taken in the last hour
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/waitlist/premium/route.ts
+++ b/src/app/api/waitlist/premium/route.ts
@@ -117,51 +117,66 @@ export async function POST(req: Request) {
   }
 
   try {
+    type SpotConfig = { total_spots: number; spots_taken: number };
+
     const result = db.transaction(() => {
+      // Release expired reservations before checking availability
+      db.prepare('DELETE FROM spot_reservations WHERE expires_at <= ? AND confirmed = 0').run(now);
+
       // Check if already on premium waitlist
       const existing = db
-        .prepare(
-          'SELECT id, position FROM premium_waitlist WHERE email_hash = ? LIMIT 1'
-        )
+        .prepare('SELECT id, position FROM premium_waitlist WHERE email_hash = ? LIMIT 1')
         .get(emailHash) as { id: string; position: number } | undefined;
 
       if (existing) {
-        // Already on list - return existing position
-        return {
-          isNew: false,
-          position: existing.position,
-          email: normalizedEmail,
-        };
+        // Mark any reservation as confirmed
+        db.prepare('UPDATE spot_reservations SET confirmed = 1 WHERE email_hash = ?').run(emailHash);
+        return { isNew: false, position: existing.position, email: normalizedEmail };
       }
 
-      // Get the next position
+      // Verify a spot is available (reservation or open pool)
+      const config = db
+        .prepare('SELECT total_spots, spots_taken FROM premium_spot_config WHERE id = 1')
+        .get() as SpotConfig;
+
+      const reservation = db
+        .prepare('SELECT id FROM spot_reservations WHERE email_hash = ? AND expires_at > ?')
+        .get(emailHash, now) as { id: string } | undefined;
+
+      const activeReservations = (
+        db
+          .prepare('SELECT COUNT(*) as cnt FROM spot_reservations WHERE expires_at > ? AND confirmed = 0')
+          .get(now) as { cnt: number }
+      ).cnt;
+
+      const spotsAvailable = config.total_spots - config.spots_taken - activeReservations;
+
+      if (!reservation && spotsAvailable <= 0) {
+        throw Object.assign(new Error('No spots available'), { code: 'SPOTS_FULL' });
+      }
+
+      // Get next position and insert
       const lastRow = db
         .prepare('SELECT MAX(position) AS max_pos FROM premium_waitlist')
         .get() as { max_pos: number | null };
-
       const nextPosition = (lastRow.max_pos || 0) + 1;
 
-      // Insert into premium waitlist
-      const id = crypto.randomUUID();
       db.prepare(
         `INSERT INTO premium_waitlist
          (id, email, email_hash, name, position, interested_date, is_active, created_at)
          VALUES (?, ?, ?, ?, ?, ?, 1, ?)`
-      ).run(
-        id,
-        normalizedEmail,
-        emailHash,
-        name || null,
-        nextPosition,
-        now,
-        now
-      );
+      ).run(crypto.randomUUID(), normalizedEmail, emailHash, name || null, nextPosition, now, now);
 
-      return {
-        isNew: true,
-        position: nextPosition,
-        email: normalizedEmail,
-      };
+      // Decrement available spots and confirm/remove reservation
+      db.prepare(
+        'UPDATE premium_spot_config SET spots_taken = spots_taken + 1, updated_at = ? WHERE id = 1'
+      ).run(now);
+
+      if (reservation) {
+        db.prepare('UPDATE spot_reservations SET confirmed = 1 WHERE email_hash = ?').run(emailHash);
+      }
+
+      return { isNew: true, position: nextPosition, email: normalizedEmail };
     })();
 
     // Send confirmation email
@@ -196,6 +211,9 @@ export async function POST(req: Request) {
       { status: 200 }
     );
   } catch (error) {
+    if (error instanceof Error && (error as Error & { code?: string }).code === 'SPOTS_FULL') {
+      return NextResponse.json({ message: 'Sorry, all premium spots are taken.' }, { status: 409 });
+    }
     console.error('Premium waitlist signup error:', error);
     return NextResponse.json(
       { message: 'Failed to join waitlist. Please try again.' },

--- a/src/app/api/waitlist/spots/route.ts
+++ b/src/app/api/waitlist/spots/route.ts
@@ -1,0 +1,156 @@
+import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { z } from 'zod';
+import { getDb } from '@/lib/db';
+import { enforceRateLimit, getClientIp, normalizeEmail, sha256Hex, validateCsrf, validateSameOrigin } from '@/lib/security';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const RESERVATION_TTL_MS = 15 * 60 * 1000;
+const SOCIAL_PROOF_WINDOW_MS = 60 * 60 * 1000;
+
+type SpotConfig = {
+  total_spots: number;
+  spots_taken: number;
+  price_increase_at: number;
+  updated_at: number;
+};
+
+function releaseExpiredReservations(db: ReturnType<typeof getDb>, now: number) {
+  db.prepare(
+    'DELETE FROM spot_reservations WHERE expires_at <= ? AND confirmed = 0'
+  ).run(now);
+}
+
+/**
+ * GET /api/waitlist/spots
+ * Returns real-time scarcity stats synced to server time.
+ */
+export async function GET() {
+  const db = getDb();
+  const now = Date.now();
+
+  releaseExpiredReservations(db, now);
+
+  const config = db
+    .prepare('SELECT total_spots, spots_taken, price_increase_at, updated_at FROM premium_spot_config WHERE id = 1')
+    .get() as SpotConfig;
+
+  const activeReservations = (
+    db
+      .prepare('SELECT COUNT(*) as cnt FROM spot_reservations WHERE expires_at > ? AND confirmed = 0')
+      .get(now) as { cnt: number }
+  ).cnt;
+
+  const spotsAvailable = Math.max(0, config.total_spots - config.spots_taken - activeReservations);
+
+  const recentSignups = (
+    db
+      .prepare(
+        'SELECT COUNT(*) as cnt FROM premium_waitlist WHERE created_at >= ? AND is_active = 1'
+      )
+      .get(now - SOCIAL_PROOF_WINDOW_MS) as { cnt: number }
+  ).cnt;
+
+  return NextResponse.json(
+    {
+      spotsAvailable,
+      spotsTotal: config.total_spots,
+      spotsTaken: config.spots_taken,
+      priceIncreasesAt: config.price_increase_at,
+      serverTime: now,
+      recentSignups,
+    },
+    {
+      status: 200,
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    }
+  );
+}
+
+const ReserveSchema = z.object({ email: z.string().min(1).max(254) });
+
+/**
+ * POST /api/waitlist/spots
+ * Reserves a spot for 15 min during checkout. Idempotent for the same email.
+ */
+export async function POST(req: Request) {
+  if (!validateSameOrigin(req)) {
+    return NextResponse.json({ message: 'Invalid origin' }, { status: 403 });
+  }
+  if (!validateCsrf(req)) {
+    return NextResponse.json({ message: 'CSRF validation failed' }, { status: 403 });
+  }
+
+  const db = getDb();
+  const now = Date.now();
+  const ip = getClientIp(req);
+
+  const limit = enforceRateLimit({ db, key: `spots:ip:${ip}`, limit: 20, windowMs: 10 * 60 * 1000, now });
+  if (!limit.ok) {
+    return NextResponse.json({ message: 'Too many requests' }, { status: 429 });
+  }
+
+  let body: unknown;
+  try { body = await req.json(); } catch {
+    return NextResponse.json({ message: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = ReserveSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ message: 'Invalid request body' }, { status: 400 });
+  }
+
+  const emailHash = sha256Hex(normalizeEmail(parsed.data.email));
+
+  const result = db.transaction(() => {
+    releaseExpiredReservations(db, now);
+
+    const config = db
+      .prepare('SELECT total_spots, spots_taken FROM premium_spot_config WHERE id = 1')
+      .get() as SpotConfig;
+
+    const activeReservations = (
+      db
+        .prepare('SELECT COUNT(*) as cnt FROM spot_reservations WHERE expires_at > ? AND confirmed = 0')
+        .get(now) as { cnt: number }
+    ).cnt;
+
+    const spotsAvailable = config.total_spots - config.spots_taken - activeReservations;
+
+    // Check if caller already has an active or confirmed reservation
+    const existing = db
+      .prepare('SELECT id, expires_at, confirmed FROM spot_reservations WHERE email_hash = ?')
+      .get(emailHash) as { id: string; expires_at: number; confirmed: number } | undefined;
+
+    if (existing?.confirmed) {
+      return { reserved: true, expiresAt: null, alreadyConfirmed: true };
+    }
+
+    if (existing && existing.expires_at > now) {
+      return { reserved: true, expiresAt: existing.expires_at, alreadyConfirmed: false };
+    }
+
+    if (spotsAvailable <= 0) {
+      return { reserved: false, expiresAt: null, alreadyConfirmed: false };
+    }
+
+    const expiresAt = now + RESERVATION_TTL_MS;
+    db.prepare(
+      `INSERT INTO spot_reservations (id, email_hash, reserved_at, expires_at, confirmed)
+       VALUES (?, ?, ?, ?, 0)
+       ON CONFLICT(email_hash) DO UPDATE SET reserved_at = excluded.reserved_at, expires_at = excluded.expires_at, confirmed = 0`
+    ).run(crypto.randomUUID(), emailHash, now, expiresAt);
+
+    return { reserved: true, expiresAt, alreadyConfirmed: false };
+  })();
+
+  if (!result.reserved) {
+    return NextResponse.json({ message: 'No spots available', reserved: false }, { status: 409 });
+  }
+
+  return NextResponse.json({ reserved: true, expiresAt: result.expiresAt }, { status: 200 });
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -94,8 +94,25 @@ function initDb(database: Db) {
       FOREIGN KEY (user_id) REFERENCES users(id)
     );
 
+    CREATE TABLE IF NOT EXISTS premium_spot_config (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      total_spots INTEGER NOT NULL DEFAULT 500,
+      spots_taken INTEGER NOT NULL DEFAULT 0,
+      price_increase_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS spot_reservations (
+      id TEXT PRIMARY KEY,
+      email_hash TEXT NOT NULL UNIQUE,
+      reserved_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL,
+      confirmed INTEGER NOT NULL DEFAULT 0
+    );
+
     CREATE UNIQUE INDEX IF NOT EXISTS idx_referrals_referred_id ON referrals(referred_id);
     CREATE INDEX IF NOT EXISTS idx_referral_codes_referrer_id ON referral_codes(referrer_id);
+    CREATE INDEX IF NOT EXISTS idx_spot_reservations_expires_at ON spot_reservations(expires_at);
   `);
 
   ensureColumn(database, 'users', 'email_hash', 'TEXT');
@@ -104,6 +121,20 @@ function initDb(database: Db) {
   ensureColumn(database, 'users', 'points', 'INTEGER NOT NULL DEFAULT 0');
   ensureColumn(database, 'referrals', 'rewarded_at', 'INTEGER');
   ensureColumn(database, 'points_adjustments', 'action', 'TEXT');
+
+  // Seed the spot config row exactly once
+  const configRow = database
+    .prepare('SELECT id FROM premium_spot_config WHERE id = 1')
+    .get();
+  if (!configRow) {
+    const now = Date.now();
+    // Price increases 30 days from first boot
+    database
+      .prepare(
+        'INSERT INTO premium_spot_config (id, total_spots, spots_taken, price_increase_at, updated_at) VALUES (1, 500, 0, ?, ?)'
+      )
+      .run(now + 30 * 24 * 60 * 60 * 1000, now);
+  }
 
   database.exec(`
     CREATE TABLE IF NOT EXISTS email_verification_tokens (


### PR DESCRIPTION
i add premium_spot_config and spot_reservations tables to db schema
i seed spot config on first boot (500 spots, 30-day price deadline)
i  add /api/waitlist/spots GET/POST for live stats and 15-min checkout locks
i update premium signup to atomically decrement pool and confirm reservations
i add PremiumCountdown component with server-synced countdown, animated spot counter, progress bar, social proof, and low-stock color escalation

closes #65 